### PR TITLE
Adding support for custom fields and events + update API

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ async function setupPlugin({ config, global }) {
 }
 
 async function onEvent(event, { config, global }) {
-    if (event.event === config.triggeringEvent) {
+    const triggeringEvents = config.triggeringEvents.split(',')
+    if (triggeringEvents.indexOf(event.event) >= 0) {
         const email = getEmailFromEvent(event)
         if (email) {
             await createHubspotContact(

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-async function setupPlugin({config, global}) {
+async function setupPlugin({ config, global }) {
     global.hubspotAuth = `hapikey=${config.hubspotApiKey}`
 
     const authResponse = await fetchWithRetry(
@@ -10,14 +10,19 @@ async function setupPlugin({config, global}) {
     }
 }
 
-async function onEvent(event, {config, global}) {
+async function onEvent(event, { config, global }) {
     if (event.event === config.triggeringEvent) {
         const email = getEmailFromEvent(event)
         if (email) {
-            await createHubspotContact(email, {
-                ...event['$set'] ?? {},
-                ...event['properties'] ?? {}
-            }, global.hubspotAuth, config.additionalPropertyMappings)
+            await createHubspotContact(
+                email,
+                {
+                    ...(event['$set'] ?? {}),
+                    ...(event['properties'] ?? {})
+                },
+                global.hubspotAuth,
+                config.additionalPropertyMappings
+            )
         }
     }
 }
@@ -31,9 +36,9 @@ async function createHubspotContact(email, properties, authQs, additionalPropert
     }
 
     if (additionalPropertyMappings) {
-        for (let mapping of additionalPropertyMappings.split(",")) {
-            let postHogProperty = mapping.split(":")[0]
-            let hubSpotProperty = mapping.split(":")[1]
+        for (let mapping of additionalPropertyMappings.split(',')) {
+            let postHogProperty = mapping.split(':')[0]
+            let hubSpotProperty = mapping.split(':')[1]
             if (postHogProperty in properties) {
                 hubspotFilteredProps[hubSpotProperty] = properties[postHogProperty]
             }
@@ -44,9 +49,9 @@ async function createHubspotContact(email, properties, authQs, additionalPropert
         `https://api.hubapi.com/crm/v3/objects/contacts?${authQs}`,
         {
             headers: {
-                'Content-Type': 'application/json',
+                'Content-Type': 'application/json'
             },
-            body: JSON.stringify({properties: {email: email, ...hubspotFilteredProps}}),
+            body: JSON.stringify({ properties: { email: email, ...hubspotFilteredProps } })
         },
         'POST'
     )
@@ -63,7 +68,7 @@ async function createHubspotContact(email, properties, authQs, additionalPropert
 
 async function fetchWithRetry(url, options = {}, method = 'GET', isRetry = false) {
     try {
-        const res = await fetch(url, {method: method, ...options})
+        const res = await fetch(url, { method: method, ...options })
         return res
     } catch {
         if (isRetry) {
@@ -115,5 +120,5 @@ const hubspotPropsMap = {
     website: 'website',
     domain: 'website',
     company_website: 'website',
-    companyWebsite: 'website',
+    companyWebsite: 'website'
 }

--- a/plugin.json
+++ b/plugin.json
@@ -11,6 +11,22 @@
             "type": "string",
             "default": "",
             "required": true
+        },
+        {
+            "key": "triggeringEvent",
+            "hint": "The PostHog event you want to trigger Contact creation in HubSpot. By default, we recommend using the $identify event.",
+            "name": "Triggering event",
+            "type": "string",
+            "default": "$identify",
+            "required": true
+        },
+        {
+            "key": "additionalPropertyMappings",
+            "hint": "A mapping of additional PostHog event or person properties to map to newly created Hubspot Contacts. Provide a comma-separated mapping of: personPropertyName:hubSpotPropertyName",
+            "name": "Additional PostHog to HubSpot property mappings",
+            "type": "string",
+            "default": "",
+            "required": false
         }
     ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -13,9 +13,9 @@
             "required": true
         },
         {
-            "key": "triggeringEvent",
-            "hint": "The PostHog event you want to trigger Contact creation in HubSpot. By default, we recommend using the $identify event.",
-            "name": "Triggering event",
+            "key": "triggeringEvents",
+            "hint": "A comma-separated list of PostHog events you want to trigger Contact creation in HubSpot. By default, we recommend using the $identify event.",
+            "name": "Triggering events",
             "type": "string",
             "default": "$identify",
             "required": true


### PR DESCRIPTION
A few changes:
- Adding an optional `additionalPropertyMappings` config key to send additional properties from the event to Hubspot (for example, realm)
- Add the option to choose which event triggers contact creation
- Update the API to use `onEvent` since the docs say `processEventBatch` is deprecated