### PR TITLE
Cast Hubspot Score as an Integer

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ async function updateHubspotScore(email, hubspotScore, global) {
         for (const loadedUser of userResponse['results']) {
             const userId = loadedUser['id']
             const currentProps = loadedUser['properties'] ?? {}
-            const updatedProps = { hubspot_score: hubspotScore, ...currentProps }
+            const updatedProps = { hubspot_score: parseInt(hubspotScore), ...currentProps }
 
             if (userId) {
                 const _updateRes = await fetch(


### PR DESCRIPTION
Update HubSpot score to be parsed and ingested as an integer, so it can be handled correctly in filters.

Related to: https://github.com/PostHog/posthog/issues/8488#issuecomment-1032671938