### PR TITLE
Add createOnlyProperties

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,13 +168,14 @@ async function onEvent(event, { config, global }) {
                 },
                 global.hubspotAuth,
                 config.additionalPropertyMappings,
+                config.createOnlyProperties,
                 event['sent_at']
             )
         }
     }
 }
 
-async function createHubspotContact(email, properties, authQs, additionalPropertyMappings, eventSendTime) {
+async function createHubspotContact(email, properties, authQs, additionalPropertyMappings, createOnlyProperties, eventSendTime) {
     let hubspotFilteredProps = {}
     for (const [key, val] of Object.entries(properties)) {
         if (hubspotPropsMap[key]) {
@@ -220,6 +221,12 @@ async function createHubspotContact(email, properties, authQs, additionalPropert
             const existingIdRegex = /Existing ID: ([0-9]+)/
             const existingId = addContactResponseJson.message.match(existingIdRegex)
             console.log(`Attempting to update contact ${email} instead...`)
+            
+            if(createOnlyProperties){
+                for (createOnlyProperty of createOnlyProperties.split(',')){
+                    delete hubspotFilteredProps[createOnlyProperty]
+                }
+            }
 
             const updateContactResponse = await fetchWithRetry(
                 `https://api.hubapi.com/crm/v3/objects/contacts/${existingId[1]}?${authQs}`,

--- a/plugin.json
+++ b/plugin.json
@@ -29,6 +29,14 @@
             "required": false
         },
         {
+            "key": "createOnlyProperties",
+            "hint": "A list of properties that are only used when creating Hubspot Contacts and ignored when updating existing Hubspot Contacts. Provide a comma-separated list of: hubSpotPropertyName",
+            "name": "Create only HubSpot properties",
+            "type": "string",
+            "default": "",
+            "required": false
+        },
+        {
             "key": "ignoredEmails",
             "hint": "A comma-separated list of email domains to ignore and not create contacts for in Hubspot.",
             "name": "Email domains to skip",


### PR DESCRIPTION
This PR adds the ability for users to define fields that should only be passed to Hubspot when creating a new contact. This will prevent overriding of the specified fields if the identified person in Posthog already exists in Hubspot.

Within Hubspot it is possible to restrict field editing access to teams and users but those restrictions do not apply to API keys: https://knowledge.hubspot.com/account/restrict-edit-access-for-properties

Like the `additionalPropertyMappings` config property, users can pass the fields to `createOnlyProperties` they would like to restrict from updating using a comma separated list of Hubspot property names. If the plugin is unable to create a new contact when the contact already exists, it loops through the all of the `createOnlyProperties` and deletes them from `hubspotFilteredProps` before making the PATCH request to the existing contact.

An example problem this solves:
Hubspot contacts can either be created manually by sales reps or automatically via the Posthog integration to a webapp. When created manually, the sales reps add the value of `[sales rep name]` to a `source` property in Hubspot. If created automatically via the webapp, the value of the `source` property is set to `[web app name]`. If a contact that was manually added to Hubspot signs up for the webapp, the `source` field of the contact will no longer be updated to `[web app name]`.