### PR TITLE
Remove option to sync scores to PostHog

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,5 @@
 import { RetryError } from '@posthog/plugin-scaffold'
 
-const NEXT_CONTACT_BATCH_KEY = 'next_hubspot_contacts_url'
-const SYNC_LAST_COMPLETED_DATE_KEY = 'last_job_complete_day'
-
 const hubspotPropsMap = {
     companyName: 'company',
     company_name: 'company',
@@ -22,22 +19,9 @@ const hubspotPropsMap = {
     companyWebsite: 'website'
 }
 
-export const jobs = {
-    'Clear storage': async (_, { storage }) => {
-        await storage.del(NEXT_CONTACT_BATCH_KEY)
-        await storage.del(SYNC_LAST_COMPLETED_DATE_KEY)
-    }
-}
-
 export async function setupPlugin({ config, global }) {
     try {
-        global.syncMode = config.syncMode
         global.hubspotAccessToken = config.hubspotAccessToken
-        global.posthogUrl = config.postHogUrl
-        global.posthogApiKey = config.posthogApiKey
-        global.posthogProjectKey = config.posthogProjectKey
-
-        global.syncScoresIntoPosthog = global.posthogUrl
 
         const authResponse = await fetch(
             `https://api.hubapi.com/crm/v3/objects/contacts?limit=1&paginateAssociations=false&archived=false`,
@@ -55,145 +39,6 @@ export async function setupPlugin({ config, global }) {
     } catch (error) {
         throw new RetryError(error)
     }
-}
-
-export async function runEveryMinute({ global, storage }) {
-    if (!global.syncScoresIntoPosthog) {
-        console.log('Not syncing Hubspot Scores into PostHog - config not set.')
-        return
-    }
-
-    const loadedContacts = await getHubspotContacts(global, storage)
-    let skipped = 0
-    let num_updated = 0
-    let num_processed = 0
-    let num_errors = 0
-    for (const hubspotContact of loadedContacts) {
-        const email = hubspotContact['email']
-        const score = hubspotContact['score']
-
-        if (email && score) {
-            try {
-                const updated = await updateHubspotScore(email, score, global)
-
-                if (updated) {
-                    num_updated += 1
-                } else {
-                    skipped += 1
-                }
-            } catch (error) {
-                console.error(error.stack || error)
-                console.log(`Error updating Hubspot score for ${email} - Skipping`)
-                num_errors += 1
-            }
-        }
-
-        num_processed += 1
-    }
-
-    console.log(
-        `Successfully updated Hubspot scores for ${num_updated} records, skipped ${skipped} records, processed ${num_processed} Hubspot Contacts, errors: ${num_errors} `
-    )
-
-    const nextContactBatch = await storage.get(NEXT_CONTACT_BATCH_KEY)
-    if (!nextContactBatch) {
-        posthog.capture('hubspot contact sync all contacts completed', { num_updated: num_updated })
-
-        const dateObj = new Date()
-        await storage.set(
-            SYNC_LAST_COMPLETED_DATE_KEY,
-            `${dateObj.getUTCFullYear()}-${dateObj.getUTCMonth()}-${dateObj.getUTCDate()}`
-        )
-    } else {
-        posthog.capture('hubspot contact sync batch completed', { num_updated: num_updated })
-    }
-}
-
-async function getHubspotContacts(global, storage) {
-    const properties = ['email', 'hubspotscore']
-
-    let requestUrl = await storage.get(NEXT_CONTACT_BATCH_KEY)
-    if (!requestUrl) {
-        const lastFinishDate = await storage.get(SYNC_LAST_COMPLETED_DATE_KEY)
-        const dateObj = new Date()
-        const todayStr = `${dateObj.getUTCFullYear()}-${dateObj.getUTCMonth()}-${dateObj.getUTCDate()}`
-
-        if (todayStr === lastFinishDate && global.syncMode === 'production') {
-            console.log(`Not syncing contacts - sync already completed for ${todayStr}`)
-            return []
-        }
-
-        // start fresh - begin processing all contacts
-        requestUrl = `https://api.hubapi.com/crm/v3/objects/contacts?limit=100&paginateAssociations=false&archived=false&properties=${properties.join(
-            ','
-        )}`
-    }
-
-    const loadedContacts = []
-    const authResponse = await fetch(requestUrl, {
-        headers: {
-            Authorization: `Bearer ${global.hubspotAccessToken}`,
-            'Content-Type': 'application/json'
-        }
-    })
-    const res = await authResponse.json()
-
-    if (!statusOk(authResponse) || res.status === 'error') {
-        const errorMessage = res.message ?? ''
-        console.error(
-            `Unable to get contacts from Hubspot. Status Code: ${authResponse.status}. Error message: ${errorMessage}`
-        )
-    }
-
-    if (res && res['results']) {
-        res['results'].forEach((hubspotContact) => {
-            const props = hubspotContact['properties']
-            loadedContacts.push({ email: props['email'], score: props['hubspotscore'] })
-        })
-    }
-
-    let nextContactBatch
-    res['paging'] && res['paging']['next']
-        ? (nextContactBatch = res['paging']['next']['link'] + `&${global.hubspotAuth}`)
-        : null
-
-    await storage.set(NEXT_CONTACT_BATCH_KEY, nextContactBatch)
-    console.log(`Loaded ${loadedContacts.length} Contacts from Hubspot`)
-    return loadedContacts
-}
-
-async function updateHubspotScore(email: string, hubspotScore: string, global) {
-    let updated = false
-
-    const userRes = await posthog.api.get(`/api/projects/@current/persons?email=${encodeURIComponent(email)}`, {
-        host: global.posthogUrl,
-        personalApiKey: global.posthogApiKey,
-        projectApiKey: global.posthogProjectKey
-    })
-    const userResponse = await userRes.json()
-
-    if (userResponse.results && userResponse.results.length > 0) {
-        for (const loadedUser of userResponse['results']) {
-            const userId = loadedUser['id']
-            const distinct_id = loadedUser['distinct_ids'][0]
-
-            if (userId) {
-                console.log(`Updated Person ${email} with score ${hubspotScore}`)
-
-                posthog.capture('hubspot score updated', {
-                    distinct_id: distinct_id,
-                    hubspot_score: hubspotScore,
-                    $set: {
-                        hubspot_score: parseInt(hubspotScore, 10)
-                    }
-                })
-
-                updated = true
-            }
-        }
-    }
-
-    return updated
 }
 
 export async function onEvent(event, { config, global }) {

--- a/plugin.json
+++ b/plugin.json
@@ -39,15 +39,15 @@
         },
         {
             "key": "postHogUrl",
-            "hint": "The PostHog instance URL you want Hubspot Scores synced into. Required to sync Hubspot contact scores into PostHog Persons.",
+            "hint": "Deprecated",
             "name": "PostHog Instance",
             "type": "string",
             "default": "https://app.posthog.com",
-            "required": true
+            "required": false
         },
         {
             "key": "posthogApiKey",
-            "hint": "An API key used to access the PostHog API. Note that this is not the same as the Project API key",
+            "hint": "Deprecated",
             "name": "PostHog API Key",
             "type": "string",
             "default": "",
@@ -56,7 +56,7 @@
         },
         {
             "key": "posthogProjectKey",
-            "hint": "Project API key for the current project",
+            "hint": "Deprecated",
             "name": "Project API Key",
             "type": "string",
             "default": "",
@@ -65,11 +65,11 @@
         },
         {
             "key": "syncMode",
-            "hint": "If run in debug mode, run each minute and ignore cache. Do not use this in production, only for debugging",
+            "hint": "Deprecated",
             "name": "Debug Mode",
             "type": "choice",
             "default": "production",
-            "required": true,
+            "required": false,
             "choices": ["production", "debug"]
         }
     ],


### PR DESCRIPTION
The runEveryMinute functionality is being deprecated. Currently users don't seem to be using it outside of PostHog team, for which we'll have https://github.com/PostHog/hubspot-plugin-syncscores

I'm not sure what would happen to properties if they were removed, so I didn't and just made them not required.
